### PR TITLE
Rework Default Generator MRO Logic

### DIFF
--- a/traitlets/tests/test_traitlets.py.orig
+++ b/traitlets/tests/test_traitlets.py.orig
@@ -17,11 +17,19 @@ import nose.tools as nt
 from nose import SkipTest
 
 from traitlets import (
+<<<<<<< HEAD
     HasTraits, MetaHasDescriptors, TraitType, Any, Bool, CBytes, Dict, Enum,
     Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError,
     Union, All, Undefined, Type, This, Instance, TCPAddress, List, Tuple,
     ObjectName, DottedObjectName, CRegExp, link, directional_link,
-    ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default
+    ForwardDeclaredType, ForwardDeclaredInstance, validate, observe
+=======
+    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
+    Int, Long, Integer, Float, Complex, Bytes, Unicode, TraitError, Union,
+    Undefined, Type, This, Instance, TCPAddress, List, Tuple, ObjectName,
+    DottedObjectName, CRegExp, link, directional_link, ForwardDeclaredType,
+    ForwardDeclaredInstance, validate, observe, default
+>>>>>>> default generators
 )
 from ipython_genutils import py3compat
 from ipython_genutils.testing.decorators import skipif

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -483,13 +483,7 @@ class TraitType(BaseDescriptor):
         if silent is not True:
             # we explicitly compare silent to True just in case the equality
             # comparison above returns something other than True/False
-            obj._notify_change(self.name, 'trait_change', {
-                'name': self.name,
-                'old': old_value,
-                'new': new_value,
-                'owner': obj,
-                'type': 'trait_change',
-            })
+            obj._notify_trait(self.name, old_value, new_value)
 
     def __set__(self, obj, value):
         if self.read_only:
@@ -864,6 +858,15 @@ class HasTraits(HasDescriptors):
                 for changes in cache.values():
                     for change in changes:
                         self._notify_change(change['name'], change['type'], change)
+
+    def _notify_trait(self, name, old_value, new_value):
+        self._notify_change(name, 'trait_change', {
+            'name': name,
+            'old': old_value,
+            'new': new_value,
+            'owner': self,
+            'type': 'trait_change',
+        })
 
     def _notify_change(self, name, type, change):
         callables = []

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -503,7 +503,7 @@ class TraitType(BaseDescriptor):
     def _cross_validate(self, obj, value):
         if self.name in obj._trait_validators:
             proposal = {'trait': self, 'value': value, 'owner': obj}
-            value = obj._trait_validators[self.name](proposal)
+            value = obj._trait_validators[self.name](obj, proposal)
         elif hasattr(obj, '_%s_validate' % self.name):
             warn("_[traitname]_validate handlers are deprecated: use validate"
                 " decorator instead", DeprecationWarning, stacklevel=2)
@@ -703,7 +703,7 @@ class ObserveHandler(EventHandler):
 
     def instance_init(self, inst):
         meth = types.MethodType(self.func, inst)
-        inst.observe(meth, self.names, type=self.type)
+        inst.observe(self, self.names, type=self.type)
 
 class ValidateHandler(EventHandler):
 
@@ -712,7 +712,7 @@ class ValidateHandler(EventHandler):
     
     def instance_init(self, inst):
         meth = types.MethodType(self.func, inst)
-        inst._register_validator(meth, self.names)
+        inst._register_validator(self, self.names)
 
 
 class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
@@ -895,9 +895,12 @@ class HasTraits(HasDescriptors):
 
             if isinstance(c, _CallbackWrapper):
                 # _CallbackWrappers are not compatible with getargspec and have one argument
-                nargs = 1
-            else:
-                nargs = len(getargspec(c)[0]) + offset
+                c = c.__call__
+            elif isinstance(c, EventHandler):
+                c = getattr(self, c.name)
+
+            offset = 1 if isinstance(c, types.MethodType) else 0
+            nargs = len(getargspec(c)[0]) - offset
 
             if nargs == 0:
                 c()

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -891,7 +891,6 @@ class HasTraits(HasDescriptors):
         # Traits catches and logs errors here.  I allow them to raise
         for c in callables:
             # Bound methods have an additional 'self' argument.
-            offset = -1 if isinstance(c, types.MethodType) else 0
 
             if isinstance(c, _CallbackWrapper):
                 # _CallbackWrappers are not compatible with getargspec and have one argument

--- a/traitlets/traitlets.py.orig
+++ b/traitlets/traitlets.py.orig
@@ -743,6 +743,10 @@ class ValidateHandler(EventHandler):
         inst._register_validator(meth, self.names)
 
 
+<<<<<<< HEAD
+class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
+    """The base class for all classes that have descriptors.
+=======
 class DefaultHandler(EventHandler):
 
     def __init__(self, name):
@@ -751,8 +755,10 @@ class DefaultHandler(EventHandler):
     def instance_init(self, inst):
         inst._trait_default_generators[self._name] = self
 
-class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
-    """The base class for all classes that have descriptors.
+
+class HasTraits(py3compat.with_metaclass(MetaHasTraits, object)):
+    """The base class for all classes that have traitlets.
+>>>>>>> default generators
     """
 
     def __new__(cls, *args, **kw):
@@ -763,10 +769,20 @@ class HasDescriptors(py3compat.with_metaclass(MetaHasDescriptors, object)):
             inst = new_meth(cls)
         else:
             inst = new_meth(cls, **kw)
+<<<<<<< HEAD
         inst.install_descriptors(cls)
         return inst
 
     def install_descriptors(self, cls):
+=======
+        inst._trait_values = {}
+        inst._trait_default_generators = {}
+        inst._trait_notifiers = {}
+        inst._trait_validators = {}
+        inst._cross_validation_lock = True
+        # Here we tell all the TraitType instances to set their default
+        # values on the instance.
+>>>>>>> default generators
         for key in dir(cls):
             # Some descriptors raise AttributeError like zope.interface's
             # __provides__ attributes even though they exist.  This causes
@@ -784,7 +800,6 @@ class HasTraits(HasDescriptors):
 
     def install_descriptors(self, cls):
         self._trait_values = {}
-        self._trait_default_generators = {}
         self._trait_notifiers = {}
         self._trait_validators = {}
         super(HasTraits, self).install_descriptors(cls)


### PR DESCRIPTION
The only thing odd about this approach to the default decorator is that the default handlers remain in `_trait_default_generators` even if they don't generate default values due to the `mro` logic. That seems unintuitive to me so I've reworked things slightly by putting the `mro` logic on the default handler's `instance_init` method so that it's only put in `_trait_default_generators` if it will actually be used to create a default value.
